### PR TITLE
feat: add /init command to generate and auto-load project context

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch"
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "ava"
 	},
 	"files": [
 		"dist"

--- a/src/commands/definitions/init.ts
+++ b/src/commands/definitions/init.ts
@@ -1,0 +1,23 @@
+import { CommandDefinition, CommandContext } from '../base.js';
+import { writeProjectContext } from '../../utils/context.js';
+
+export const initCommand: CommandDefinition = {
+  command: 'init',
+  description: 'Generate project context files in .groq/',
+  handler: ({ addMessage }: CommandContext) => {
+    try {
+      const rootDir = process.env.GROQ_CONTEXT_DIR || process.cwd();
+      const { mdPath, jsonPath } = writeProjectContext(rootDir);
+      addMessage({
+        role: 'system',
+        content: `Project context generated.\n- Markdown: ${mdPath}\n- JSON: ${jsonPath}\nThe assistant will automatically load this context on startup. Re-run /init to refresh.`
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      addMessage({
+        role: 'system',
+        content: `Failed to generate project context: ${message}`
+      });
+    }
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import { helpCommand } from './definitions/help.js';
 import { loginCommand } from './definitions/login.js';
 import { modelCommand } from './definitions/model.js';
 import { clearCommand } from './definitions/clear.js';
+import { initCommand } from './definitions/init.js';
 import { reasoningCommand } from './definitions/reasoning.js';
 
 const availableCommands: CommandDefinition[] = [
@@ -10,6 +11,7 @@ const availableCommands: CommandDefinition[] = [
   loginCommand,
   modelCommand,
   clearCommand,
+  initCommand,
   reasoningCommand,
 ];
 

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -55,6 +55,27 @@ export class Agent {
 
     // Add system message to conversation
     this.messages.push({ role: 'system', content: this.systemMessage });
+
+    // Load project context if available
+    try {
+      const explicitContextFile = process.env.GROQ_CONTEXT_FILE;
+      const baseDir = process.env.GROQ_CONTEXT_DIR || process.cwd();
+      const contextPath = explicitContextFile || path.join(baseDir, '.groq', 'context.md');
+      const contextLimit = parseInt(process.env.GROQ_CONTEXT_LIMIT || '20000', 10);
+      if (fs.existsSync(contextPath)) {
+        const ctx = fs.readFileSync(contextPath, 'utf-8');
+        const trimmed = ctx.length > contextLimit ? ctx.slice(0, contextLimit) + '\n... [truncated]' : ctx;
+        const contextSource = explicitContextFile ? contextPath : '.groq/context.md';
+        this.messages.push({
+          role: 'system',
+          content: `Project context loaded from ${contextSource}. Use this as high-level reference when reasoning about the repository.\n\n${trimmed}`
+        });
+      }
+    } catch (error) {
+      if (debugEnabled) {
+        debugLog('Failed to load project context:', error);
+      }
+    }
   }
 
   static async create(

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,304 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { shouldIgnore } from './file-ops.js';
+
+export interface ProjectContextJson {
+  generated_at: string;
+  root: string;
+  summary: {
+    total_files: number;
+    total_directories: number;
+    languages: Array<{ extension: string; files: number }>;
+  };
+  package?: {
+    name?: string;
+    version?: string;
+    description?: string;
+    scripts?: string[];
+    dependencies_count?: number;
+    dev_dependencies_count?: number;
+  };
+  config_files: string[];
+  notable_files: string[];
+  tree: string[]; // directory tree lines
+}
+
+export interface GenerateContextOptions {
+  maxDepth?: number; // max directory depth to traverse
+  maxEntries?: number; // max number of files/dirs to include in tree
+}
+
+const DEFAULT_OPTIONS: Required<GenerateContextOptions> = {
+  maxDepth: 3,
+  maxEntries: 1500,
+};
+
+export function generateProjectContext(rootDir: string = process.cwd(), options: GenerateContextOptions = {}): { json: ProjectContextJson; markdown: string } {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const root = path.resolve(rootDir);
+  // Validate root directory exists and is accessible
+  let rootStat: fs.Stats;
+  try {
+    rootStat = fs.statSync(root);
+  } catch {
+    throw new Error(`Root directory does not exist or is not accessible: ${root}`);
+  }
+  if (!rootStat.isDirectory()) {
+    throw new Error(`Root path is not a directory: ${root}`);
+  }
+
+  const stats = walkDirectory(root, opts.maxDepth, opts.maxEntries);
+
+  const languages = Object.entries(stats.extensionCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([ext, count]) => ({ extension: ext || '(none)', files: count }));
+
+  const pkg = readPackageJson(root);
+
+  const configFiles = stats.allFiles
+    .filter(fp => isConfigFile(fp))
+    .map(fp => path.relative(root, fp))
+    .sort();
+
+  const notableFiles = stats.allFiles
+    .filter(fp => isNotableFile(fp))
+    .map(fp => path.relative(root, fp))
+    .sort();
+
+  const treeLines = renderTree(stats.treeNodes);
+
+  const json: ProjectContextJson = {
+    generated_at: new Date().toISOString(),
+    root,
+    summary: {
+      total_files: stats.fileCount,
+      total_directories: stats.dirCount,
+      languages,
+    },
+    package: pkg || undefined,
+    config_files: configFiles,
+    notable_files: notableFiles,
+    tree: treeLines,
+  };
+
+  const markdown = buildMarkdown(json);
+
+  return { json, markdown };
+}
+
+export function writeProjectContext(rootDir: string = process.cwd(), options: GenerateContextOptions = {}): { mdPath: string; jsonPath: string } {
+  const { json, markdown } = generateProjectContext(rootDir, options);
+
+  const outputDir = path.join(rootDir, '.groq');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const mdPath = path.join(outputDir, 'context.md');
+  const jsonPath = path.join(outputDir, 'context.json');
+
+  fs.writeFileSync(mdPath, markdown, 'utf-8');
+  fs.writeFileSync(jsonPath, JSON.stringify(json, null, 2), 'utf-8');
+
+  return { mdPath, jsonPath };
+}
+
+function readPackageJson(rootDir: string): ProjectContextJson['package'] | null {
+  const pkgPath = path.join(rootDir, 'package.json');
+  try {
+    if (!fs.existsSync(pkgPath)) return null;
+    const raw = fs.readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw);
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      scripts: pkg.scripts ? Object.keys(pkg.scripts) : [],
+      dependencies_count: pkg.dependencies ? Object.keys(pkg.dependencies).length : 0,
+      dev_dependencies_count: pkg.devDependencies ? Object.keys(pkg.devDependencies).length : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isConfigFile(filePath: string): boolean {
+  const base = path.basename(filePath).toLowerCase();
+  const configNames = new Set([
+    'package.json', 'tsconfig.json', 'jsconfig.json', 'pyproject.toml', 'poetry.lock', 'requirements.txt',
+    'go.mod', 'go.sum', 'cargo.toml', 'cargo.lock', 'composer.json', 'composer.lock', 'gemfile', 'gemfile.lock',
+    'pipfile', 'pipfile.lock', 'dockerfile', 'docker-compose.yml', '.dockerignore', '.gitignore', '.env', '.editorconfig',
+    '.eslintrc', '.eslintrc.js', '.prettierrc', '.prettierrc.js', 'makefile', 'justfile',
+  ]);
+  return configNames.has(base);
+}
+
+function isNotableFile(filePath: string): boolean {
+  const base = path.basename(filePath).toLowerCase();
+  return base.startsWith('readme') || base === 'license' || base === 'license.md' || base.endsWith('.md');
+}
+
+interface TreeNode {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children: TreeNode[];
+}
+
+function walkDirectory(root: string, maxDepth: number, maxEntries: number): {
+  treeNodes: TreeNode[];
+  fileCount: number;
+  dirCount: number;
+  extensionCounts: Record<string, number>;
+  allFiles: string[];
+} {
+  let fileCount = 0;
+  let dirCount = 0;
+  let totalEntries = 0;
+  const extensionCounts: Record<string, number> = {};
+  const allFiles: string[] = [];
+
+  function isDirectorySafe(p: string): boolean {
+    try {
+      return fs.statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  function walk(current: string, depth: number): TreeNode | null {
+    if (depth > maxDepth) return null;
+    if (totalEntries >= maxEntries) return null;
+
+    const name = path.basename(current);
+    let isDir = false;
+    try {
+      const stat = fs.statSync(current);
+      isDir = stat.isDirectory();
+    } catch {
+      // File might have been deleted or is inaccessible
+      return null;
+    }
+
+    if (depth === 0 && shouldIgnore(current)) {
+      // Do not ignore the root itself; only skip if ignore would exclude it intentionally.
+    }
+
+    if (depth > 0 && shouldIgnore(current)) {
+      return null;
+    }
+
+    const node: TreeNode = { name, path: current, isDir, children: [] };
+    totalEntries++;
+
+    if (isDir) {
+      dirCount++;
+      let entries: string[] = [];
+      try {
+        entries = fs.readdirSync(current).map(e => path.join(current, e));
+      } catch {
+        entries = [];
+      }
+      // Sort: dirs first then files alphabetically
+      entries.sort((a, b) => {
+        const aDir = isDirectorySafe(a);
+        const bDir = isDirectorySafe(b);
+        if (aDir !== bDir) return aDir ? -1 : 1;
+        return path.basename(a).toLowerCase().localeCompare(path.basename(b).toLowerCase());
+      });
+
+      for (const entry of entries) {
+        if (totalEntries >= maxEntries) break;
+        const child = walk(entry, depth + 1);
+        if (child) node.children.push(child);
+      }
+    } else {
+      fileCount++;
+      allFiles.push(current);
+      const ext = path.extname(name).replace(/^\./, '');
+      extensionCounts[ext] = (extensionCounts[ext] || 0) + 1;
+    }
+
+    return node;
+  }
+
+  const rootEntries = fs.readdirSync(root).map(e => path.join(root, e));
+  const nodes: TreeNode[] = [];
+  for (const entry of rootEntries) {
+    if (totalEntries >= maxEntries) break;
+    const child = walk(entry, 1);
+    if (child) nodes.push(child);
+  }
+
+  return { treeNodes: nodes, fileCount, dirCount, extensionCounts, allFiles };
+}
+
+function renderTree(nodes: TreeNode[]): string[] {
+  const lines: string[] = [];
+
+  function render(node: TreeNode, prefix: string, isLast: boolean) {
+    const connector = prefix ? (isLast ? '└── ' : '├── ') : '';
+    const name = node.isDir ? `${node.name}/` : node.name;
+    lines.push(`${prefix}${connector}${name}`);
+
+    const childPrefix = prefix + (prefix ? (isLast ? '    ' : '│   ') : '');
+    node.children.forEach((child, index) => {
+      const last = index === node.children.length - 1;
+      render(child, childPrefix, last);
+    });
+  }
+
+  nodes.forEach((n, idx) => render(n, '', idx === nodes.length - 1));
+  return lines;
+}
+
+function buildMarkdown(ctx: ProjectContextJson): string {
+  const lines: string[] = [];
+  lines.push(`# Project Context`);
+  lines.push('');
+  lines.push(`Generated: ${ctx.generated_at}`);
+  lines.push('');
+  lines.push(`Root: ${ctx.root}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(`- Files: ${ctx.summary.total_files}`);
+  lines.push(`- Directories: ${ctx.summary.total_directories}`);
+  if (ctx.package) {
+    lines.push(`- Package: ${ctx.package.name || ''} ${ctx.package.version ? `v${ctx.package.version}` : ''}`.trim());
+    if (ctx.package.description) lines.push(`- Description: ${ctx.package.description}`);
+    lines.push(`- Scripts: ${ctx.package.scripts?.length || 0}`);
+    lines.push(`- Dependencies: ${ctx.package.dependencies_count || 0}`);
+    lines.push(`- Dev Dependencies: ${ctx.package.dev_dependencies_count || 0}`);
+  }
+  lines.push('');
+  lines.push('## Languages (by file count)');
+  const langLines = ctx.summary.languages.slice(0, 12).map(l =>
+    l.extension === '(none)'
+      ? `- ${l.extension}: ${l.files}`
+      : `- .${l.extension}: ${l.files}`
+  );
+  lines.push(...(langLines.length ? langLines : ['- (no code files detected)']));
+
+  if (ctx.config_files.length) {
+    lines.push('');
+    lines.push('## Configuration Files');
+    ctx.config_files.forEach(f => lines.push(`- ${f}`));
+  }
+
+  if (ctx.notable_files.length) {
+    lines.push('');
+    lines.push('## Notable Files');
+    ctx.notable_files.forEach(f => lines.push(`- ${f}`));
+  }
+
+  if (ctx.tree.length) {
+    lines.push('');
+    lines.push('## Directory Tree');
+    lines.push('```');
+    ctx.tree.forEach(l => lines.push(l));
+    lines.push('```');
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('This file is auto-generated. Re-run the init command to refresh.');
+  return lines.join('\n');
+}

--- a/test/agent-context-load.test.ts
+++ b/test/agent-context-load.test.ts
@@ -1,0 +1,56 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Agent } from '../src/core/agent.js';
+
+function setupDirWithContext(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-agentctx-'));
+  const ctxDir = path.join(tmp, '.groq');
+  fs.mkdirSync(ctxDir);
+  fs.writeFileSync(path.join(ctxDir, 'context.md'), 'HelloCtx\n');
+  return tmp;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+test('Agent auto-loads .groq/context.md as system message', async t => {
+  const dir = setupDirWithContext();
+  const original = { ...process.env };
+  (process.env as any).GROQ_CONTEXT_DIR = dir;
+  try {
+    const agent = await Agent.create('test-model', 1.0, null, false);
+    const msgs = (agent as any).messages as Array<{ role: string; content: string }>;
+    const found = msgs.find(m => m.role === 'system' && m.content.includes('Project context loaded from .groq/context.md'));
+    t.truthy(found);
+    t.true(found!.content.includes('HelloCtx'));
+  } finally {
+    // restore env
+    for (const k of Object.keys(process.env)) delete (process.env as any)[k];
+    Object.assign(process.env, original);
+    cleanupDir(dir);
+  }
+});
+
+test('Agent handles missing context gracefully', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-nocontext-'));
+  const original = { ...process.env };
+  (process.env as any).GROQ_CONTEXT_DIR = dir;
+  try {
+    const agent = await Agent.create('test-model', 1.0, null, false);
+    const msgs = (agent as any).messages as Array<{ role: string; content: string }>;
+    // Should only have the default system message
+    t.is(msgs.filter(m => m.role === 'system').length, 1);
+    t.false(msgs[0].content.includes('Project context loaded'));
+  } finally {
+    for (const k of Object.keys(process.env)) delete (process.env as any)[k];
+    Object.assign(process.env, original);
+    cleanupDir(dir);
+  }
+});

--- a/test/context-generator.test.ts
+++ b/test/context-generator.test.ts
@@ -1,0 +1,66 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { generateProjectContext, writeProjectContext } from '../src/utils/context.js';
+
+function makeTempProject(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-context-'));
+  // Create files and dirs
+  fs.mkdirSync(path.join(tmp, 'src'));
+  fs.mkdirSync(path.join(tmp, 'docs'));
+  fs.writeFileSync(path.join(tmp, 'src', 'index.ts'), 'export const x = 1;\n');
+  fs.writeFileSync(path.join(tmp, 'README.md'), '# Readme\n');
+  fs.writeFileSync(path.join(tmp, 'docs', 'guide.md'), '# Guide\n');
+  fs.writeFileSync(
+    path.join(tmp, 'package.json'),
+    JSON.stringify({ name: 'tmp-proj', version: '0.1.0', scripts: { build: 'tsc' } }, null, 2),
+    'utf-8'
+  );
+  return tmp;
+}
+
+function cleanupTempDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+test('generateProjectContext returns summary, languages, and lists', t => {
+  const root = makeTempProject();
+  try {
+    const { json, markdown } = generateProjectContext(root, { maxDepth: 4 });
+
+    t.truthy(json.generated_at);
+    t.is(json.root, path.resolve(root));
+    t.true(json.summary.total_files >= 3);
+    t.true(json.summary.total_directories >= 2);
+    t.true(json.summary.languages.length >= 1);
+    t.true(Array.isArray(json.config_files));
+    t.true(Array.isArray(json.notable_files));
+    t.true(Array.isArray(json.tree));
+    t.true(markdown.includes('# Project Context'));
+    t.true(markdown.includes('## Directory Tree'));
+  } finally {
+    cleanupTempDir(root);
+  }
+});
+
+test('writeProjectContext writes .groq/context.{md,json}', t => {
+  const root = makeTempProject();
+  try {
+    const { mdPath, jsonPath } = writeProjectContext(root, { maxDepth: 4 });
+
+    t.true(fs.existsSync(mdPath));
+    t.true(fs.existsSync(jsonPath));
+
+    const md = fs.readFileSync(mdPath, 'utf-8');
+    const obj = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+    t.true(md.includes('Project Context'));
+    t.is(obj.root, path.resolve(root));
+  } finally {
+    cleanupTempDir(root);
+  }
+});

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,0 +1,45 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initCommand } from '../src/commands/definitions/init.js';
+
+function makeTempProject(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-initcmd-'));
+  fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'p', version: '0.0.0' }));
+  return tmp;
+}
+
+test('/init command generates context and posts system message', t => {
+  const root = makeTempProject();
+  const messages: any[] = [];
+  const original = process.env.GROQ_CONTEXT_DIR;
+  process.env.GROQ_CONTEXT_DIR = root;
+  try {
+    initCommand.handler({
+      addMessage: (m: any) => messages.push(m),
+      clearHistory: () => {},
+      setShowLogin: () => {},
+    });
+
+    const ctxDir = path.join(root, '.groq');
+    t.true(fs.existsSync(path.join(ctxDir, 'context.md')));
+    t.true(fs.existsSync(path.join(ctxDir, 'context.json')));
+    t.true(fs.statSync(path.join(ctxDir, 'context.md')).size > 0);
+    t.true(fs.statSync(path.join(ctxDir, 'context.json')).size > 0);
+
+    t.true(messages.some(m => m.role === 'system' && String(m.content).includes('Project context generated.')));
+  } finally {
+    if (original === undefined) {
+      delete (process.env as any).GROQ_CONTEXT_DIR;
+    } else {
+      process.env.GROQ_CONTEXT_DIR = original;
+    }
+    // Cleanup temporary project directory
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+});


### PR DESCRIPTION
- Add /init command that generates .groq/context.md and .groq/context.json containing repository tree, languages, config files, and summary
- Auto-load project context at agent startup as system message when available
- Support environment overrides (GROQ_CONTEXT_FILE, GROQ_CONTEXT_DIR)
- Add comprehensive test suite using AVA for context generation and loading
- Include npm test script for easier test execution
- Apply robustness improvements for error handling and edge cases